### PR TITLE
jsdom 4.0.0 release no longer works with Node.js™.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"author": "Evan Wallace",
 	"main": "packer",
 	"dependencies": {
-		"jsdom": ">= 0.1.23",
+		"jsdom": ">= 0.1.23 < 4.0.0",
 		"htmlparser": ">= 1.7.3",
 		"nomnom": ">= 1.0.0"
 	},


### PR DESCRIPTION
This error occurs when using Node.js™ instead of io.js: https://github.com/tmpvar/jsdom#install
